### PR TITLE
Check for Composer dependency before loading Composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Page Cache Control` will be documented in this file.
 
+## v0.1.3 - 2024-03-08
+
+- Check for already-loaded Composer dependencies before loading them again.
+
 ## v0.1.2 - 2024-02-29
 
 - Fixing bug with Pantheon Provider not properly detecting the user's IP address.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
-        "mantle-framework/support": "^0.11|^0.12"
+        "mantle-framework/support": "^0.11|^0.12|^1.0"
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^2.0",

--- a/wp-page-cache-control.php
+++ b/wp-page-cache-control.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Page Cache Control
  * Plugin URI: https://github.com/alleyinteractive/wp-page-cache-control
  * Description: Control and modify the page cache for multiple hosting providers.
- * Version: 0.1.2
+ * Version: 0.1.3
  * Author: Sean Fisher
  * Author URI: https://github.com/alleyinteractive/wp-page-cache-control
  * Requires at least: 5.9

--- a/wp-page-cache-control.php
+++ b/wp-page-cache-control.php
@@ -29,10 +29,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WP_PAGE_CACHE_CONTROL_DIR', __DIR__ );
 
-// Check if Composer is installed (remove if Composer is not required for your plugin).
-if ( ! file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
-	// Check if we can resolve a Composer dependency before loading the plugin.
-	if ( ! class_exists( \Mantle\Support\Str::class ) ) {
+// Check if Composer is installed by checking for the existence of the Str class.
+if ( ! class_exists( \Mantle\Support\Str::class ) ) {
+	// Check if the autoloader exists. Otherwise, display an admin notice and bail.
+	if ( ! file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
 		\add_action(
 			'admin_notices',
 			function () {
@@ -45,10 +45,10 @@ if ( ! file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
 		);
 
 		return;
+	} else {
+		// Load Composer dependencies.
+		require_once __DIR__ . '/vendor/wordpress-autoload.php';
 	}
-} else {
-	// Load Composer dependencies.
-	require_once __DIR__ . '/vendor/wordpress-autoload.php';
 }
 
 // Load the plugin's main files.

--- a/wp-page-cache-control.php
+++ b/wp-page-cache-control.php
@@ -31,11 +31,8 @@ define( 'WP_PAGE_CACHE_CONTROL_DIR', __DIR__ );
 
 // Check if Composer is installed (remove if Composer is not required for your plugin).
 if ( ! file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
-	// Will also check for the presence of an already loaded Composer autoloader
-	// to see if the Composer dependencies have been installed in a parent
-	// folder. This is useful for when the plugin is loaded as a Composer
-	// dependency in a larger project.
-	if ( ! class_exists( \Composer\InstalledVersions::class ) ) {
+	// Check if we can resolve a Composer dependency before loading the plugin.
+	if ( ! class_exists( \Mantle\Support\Str::class ) ) {
 		\add_action(
 			'admin_notices',
 			function () {


### PR DESCRIPTION
Prevent a conflict when the plugin is loaded with Composer and loads conflicting dependencies. 